### PR TITLE
Feature/grchombo tweaks

### DIFF
--- a/lib/src/AMRElliptic/AMRPoissonOp.cpp
+++ b/lib/src/AMRElliptic/AMRPoissonOp.cpp
@@ -1171,7 +1171,8 @@ void AMRPoissonOp::write(const LevelData<FArrayBox>* a_data,
 #endif
 }
 
-/***/
+/**
+ * */
 // ---------------------------------------------------------
 void AMRPoissonOp::levelGSRB( LevelData<FArrayBox>&       a_phi,
                               const LevelData<FArrayBox>& a_rhs )
@@ -1329,7 +1330,7 @@ void AMRPoissonOp::looseGSRB(LevelData<FArrayBox>&       a_phi,
       {
 	// invoke physical BC's where necessary
 	{
-	  CH_TIME("AMRPoissonOp::looseGSRB::BCs");
+//	  CH_TIME("AMRPoissonOp::looseGSRB::BCs");
 	  m_bc(a_phi[dit[ibox]], dbl[dit[ibox]], m_domain, m_dx, true);
 	}
 	
@@ -1405,9 +1406,9 @@ void AMRPoissonOp::overlapGSRB(LevelData<FArrayBox>&       a_phi,
     for(int ibox = 0; ibox < nbox; ibox++)
       {
 	// invoke physical BC's where necessary
-	CH_START(tb);
+	//CH_START(tb);
 	m_bc(a_phi[dit[ibox]], dbl[dit[ibox]], m_domain, m_dx, true);
-	CH_STOP(tb);
+	//CH_STOP(tb);
 	Box region = dbl[dit[ibox]];
 	region.grow(-1); // just do the interior on the first run through
 	int whichPass = 0;

--- a/lib/src/AMRTimeDependent/AMR.cpp
+++ b/lib/src/AMRTimeDependent/AMR.cpp
@@ -1865,6 +1865,7 @@ void AMR::writeCheckpointFile() const
 
   for (int level = 0; level <= m_finest_level; ++level)
     {
+      m_amrlevels[level]->preCheckpointLevel();
       m_amrlevels[level]->writeCheckpointLevel(handle);
     }
 

--- a/lib/src/AMRTimeDependent/AMRLevel.H
+++ b/lib/src/AMRTimeDependent/AMRLevel.H
@@ -273,6 +273,17 @@ public:
 
   ///
   /**
+     Run preCheckpointLevel if data should be manipulated before a checkpoint file
+
+  */
+  virtual
+    void preCheckpointLevel ()
+    {
+    }
+
+
+  ///
+  /**
      Reads checkpoint header.
 
      This is a pure virtual function and  MUST be defined in the derived

--- a/lib/src/AMRTools/AverageF.ChF
+++ b/lib/src/AMRTools/AverageF.ChF
@@ -35,6 +35,9 @@ c     (dfm 5/25/08)
 
 #if (CH_SPACEDIM < 4)
       if (refRatio .eq. 2) then
+!$OMP  PARALLEL DO DEFAULT(FIRSTPRIVATE)
+!$OMP& COLLAPSE(1+CH_SPACEDIM) SHARED(coarse)
+!$OMP& SHARED(fine)
         do var = 0, CHF_NCOMP[coarse] - 1
           CHF_AUTOMULTIDO[box;ic]
             CHF_DTERM[
@@ -57,7 +60,11 @@ c     (dfm 5/25/08)
      &        + fine(CHF_IX[ip0+1;ip1+1;ip2+1],var) ])
           CHF_ENDDO
         enddo
+!$OMP  END PARALLEL DO
       else if (refRatio .eq. 4) then
+!$OMP  PARALLEL DO DEFAULT(FIRSTPRIVATE)
+!$OMP& COLLAPSE(1+CH_SPACEDIM) SHARED(coarse)
+!$OMP& SHARED(fine)
         do var = 0, CHF_NCOMP[coarse] - 1
           CHF_AUTOMULTIDO[box; ic]
             CHF_DTERM[
@@ -133,8 +140,12 @@ c     (dfm 5/25/08)
      &         + fine(CHF_IX[ip0+3;ip1+3;ip2+3],var) ])
           CHF_ENDDO
         enddo
+!$OMP  END PARALLEL DO
       else
 #endif
+!$OMP  PARALLEL DO DEFAULT(FIRSTPRIVATE)
+!$OMP& COLLAPSE(1+CH_SPACEDIM) SHARED(coarse)
+!$OMP& SHARED(fine)
         do var = 0, CHF_NCOMP[coarse] - 1
           CHF_AUTOMULTIDO[box;ic]
             CHF_DTERM[
@@ -154,6 +165,7 @@ c     (dfm 5/25/08)
             coarse(CHF_AUTOIX[ic],var) = coarseSum * refScale
           CHF_ENDDO
        enddo
+!$OMP  END PARALLEL DO
 #if (CH_SPACEDIM < 4)
       endif
 #endif

--- a/lib/src/BaseTools/Arena.cpp
+++ b/lib/src/BaseTools/Arena.cpp
@@ -90,7 +90,10 @@ void* BArena::alloc(size_t a_sz)
   // Thus, switching back to "malloc" may cause intermittent failure on some
   // machines!
   //void* ret =  calloc(1,a_sz);
-  void* ret =  malloc(a_sz);
+  //void* ret =  malloc(a_sz);
+  //MK (26/04/17): replaced malloc with aligned memory allocation. 2MB for huge page boundaries
+  void* ret;
+  posix_memalign(&ret,2*1024*1024,a_sz);
 
   if (ret == NULL)
   {

--- a/lib/src/BoxTools/BaseFabImplem.H
+++ b/lib/src/BoxTools/BaseFabImplem.H
@@ -619,6 +619,81 @@ template <class T> inline std::string BaseFab<T>::name()
   return rtn;
 }
 
+template <>
+inline void BaseFab<double>::performCopy(const BaseFab<double>& a_src,
+                                    const Box&        a_srcbox,
+                                    int               a_srccomp,
+                                    const Box&        a_destbox,
+                                    int               a_destcomp,
+                                    int               a_numcomp)
+{
+  CH_assert(a_src.box().contains(a_srcbox));
+  CH_assert(box().contains(a_destbox));
+  CH_assert(a_destbox.sameSize(a_srcbox));
+  CH_assert(a_srccomp  >= 0 && a_srccomp  + a_numcomp <= a_src.nComp());
+  CH_assert(a_destcomp >= 0 && a_destcomp + a_numcomp <= nComp());
+  // CH_TIME("BaseFab::performCopy")
+
+#ifdef _OPENMP
+  if (a_srcbox == a_src.box() && a_destbox == box() && a_destbox.sameSize(a_srcbox))
+    {
+      //MK: Was just for debugging so I have taken this out again.
+      //pout() << "Using OMP-optimised version of BaseFab::performCopy" << endl;
+
+      #pragma omp parallel default(shared)
+      {
+        int worker = omp_get_thread_num();
+        int workers = omp_get_num_threads();
+
+        int boxSize = size().product();
+        int workload = boxSize * a_numcomp;
+        int quo = workload / workers;
+        int rem = workload % workers;
+
+        int work_start, work_end;
+        if (worker < rem)
+          {
+            work_start = (quo + 1) * worker;
+            work_end = work_start + quo + 1;
+          }
+        else
+          {
+            work_start = (quo + 1) * rem + quo * (worker - rem);
+            work_end = work_start + quo;
+          }
+
+        int comp_start = work_start / boxSize;
+        int i_comp_start = work_start - comp_start * boxSize;
+
+        int comp_end = ((work_end - 1) / boxSize) + 1;
+        int i_comp_end = work_end - (comp_end - 1) * boxSize;
+
+        for (int comp = comp_start; comp < comp_end; ++comp)
+          {
+            const int i_start = (comp == comp_start) ? i_comp_start : 0;
+            const int i_end = (comp == comp_end - 1) ? i_comp_end : boxSize;
+
+            double *const dest = dataPtr(a_destcomp + comp);
+            const double *const src = a_src.dataPtr(a_srccomp + comp);
+
+            #pragma simd vectorlengthfor(double)
+            for (int i = i_start; i < i_end; ++i)
+              {
+                dest[i] = src[i];
+              }
+          }
+      }
+
+      return;
+    }
+#endif
+
+  ForAllThisBNNXCBN(double, a_destbox, a_destcomp, a_numcomp, a_src, a_srcbox, a_srccomp)
+  {
+    thisR = a_srcR;
+  } EndForTX
+}
+
 template <class T>
 inline void BaseFab<T>::performCopy(const BaseFab<T>& a_src,
                                     const Box&        a_srcbox,


### PR DESCRIPTION
Various tweaks to Chombo introduced as part of the work on GRChombo:
- Added a function preCheckpointLevel to AMR  …
- Threading of TimeInterpolatorRK4::interpolate
- Aligned memory allocation for boxes.  …
- Threading in AverageF::average(...)
- Threading in BaseFAB::performCopy<double>(...)
- Removed timers which caused erros in AMRPoissonOp.cpp