### PR TITLE
Fix c++11 flags in Make.defs.compiler and add some compiler notes

### DIFF
--- a/lib/mk/compiler/Make.defs.GNU
+++ b/lib/mk/compiler/Make.defs.GNU
@@ -48,8 +48,7 @@ _gppmajorver:= $(word 1,$(_gppversion))
 _gppminorver:= $(word 2,$(_gppversion))
 
   # `-ftemplate-depth' is needed to keep mangled function names from
-  #  getting too long for some linkers to handle. Note it sometimes causes problems for GRChombo, and
-  #  it seems possible to remove it without errors.
+  #  getting too long for some linkers to handle.
   # HDF5 uses `long long', so disable warnings about it.
   # `-Wno-sign-compare' turns off warnings about comparing signed and unsigned int -
   #   this is a meaningful warning, but it appears way too often in our code.

--- a/lib/mk/compiler/Make.defs.GNU
+++ b/lib/mk/compiler/Make.defs.GNU
@@ -48,12 +48,13 @@ _gppmajorver:= $(word 1,$(_gppversion))
 _gppminorver:= $(word 2,$(_gppversion))
 
   # `-ftemplate-depth' is needed to keep mangled function names from
-  #  getting too long for some linkers to handle.
+  #  getting too long for some linkers to handle. Note it sometimes causes problems for GRChombo, and
+  #  it seems possible to remove it without errors.
   # HDF5 uses `long long', so disable warnings about it.
   # `-Wno-sign-compare' turns off warnings about comparing signed and unsigned int -
   #   this is a meaningful warning, but it appears way too often in our code.
-
-_cxxbaseflags := -std=c++11 -Wno-unused-but-set-variable -Wno-long-long -Wno-sign-compare -Wno-deprecated -ftemplate-depth-55  -Wno-unused-local-typedefs -Wno-literal-suffix
+  # Changed c++11 flag into c++14 as required for GRChombo 
+_cxxbaseflags := -std=c++14 -Wno-unused-but-set-variable -Wno-long-long -Wno-sign-compare -Wno-deprecated -ftemplate-depth-55  -Wno-unused-local-typedefs -Wno-literal-suffix
 
   # g++ v3.4.0 started objecting to some uses of HOFFSET()
   # TJL - Changed moving from csh to sh...

--- a/lib/mk/compiler/Make.defs.Intel
+++ b/lib/mk/compiler/Make.defs.Intel
@@ -56,6 +56,7 @@ fdbgflags += -g -check bounds -check uninit -ftrapuv
 # The -lsvml flag has been found to give GRChombo bugs and it seems like
 # one can safely remove it. For now we will leave it in and just note in wiki.
 flibflags += -lifport -lifcore -limf -lm -lipgo -lirc -lsvml
+
 # Compile with OpenMP
 ifeq ($(OPENMPCC),TRUE)
   cxxoptflags += -qopenmp

--- a/lib/mk/compiler/Make.defs.Intel
+++ b/lib/mk/compiler/Make.defs.Intel
@@ -42,7 +42,8 @@ getcompilerversion := $(CHOMBO_HOME)/mk/compilerVersion.pl
 # -C disable stripping out C++ comments, which are valid code in Fortran
 CH_CPP = $(CXX) -EP -C
 
-_cxxbaseflags = -restrict -m64 -std=c++11
+# Changed c++11 flag into c++14 as required for GRChombo 
+_cxxbaseflags = -restrict -m64 -std=c++14
 
 cxxdbgflags += -g -Wall -Wextra -pedantic -fstack-protector-all $(_cxxbaseflags)
 cxxoptflags += -O3 -m64 -qopt-multi-version-aggressive $(_cxxbaseflags)
@@ -52,7 +53,9 @@ defldflags = -static-intel
 foptflags += -O3
 fdbgflags += -g -check bounds -check uninit -ftrapuv
 
-flibflags += -lifport -lifcore -limf -lsvml -lm -lipgo -lirc -lsvml
+# The -lsvml flag has been found to give GRChombo bugs and it seems like
+# one can safely remove it. For now we will leave it in and just note in wiki.
+flibflags += -lifport -lifcore -limf -lm -lipgo -lirc -lsvml
 # Compile with OpenMP
 ifeq ($(OPENMPCC),TRUE)
   cxxoptflags += -qopenmp

--- a/lib/mk/compiler/Make.defs.clang++
+++ b/lib/mk/compiler/Make.defs.clang++
@@ -15,8 +15,9 @@
 
 makefiles+=local/Make.defs.clang++
 
-defcxxdbgflags = -std=c++11 -g -Wall -Wno-overloaded-virtual -Wno-sign-compare
-defcxxoptflags = -std=c++11 -O3 -march=native  -Wno-sign-compare
+# Changed c++11 flag into c++14 as required for GRChombo 
+defcxxdbgflags = -std=c++14 -g -Wall -Wno-overloaded-virtual -Wno-sign-compare
+defcxxoptflags = -std=c++14 -O3 -march=native  -Wno-sign-compare
 
 ifeq ($(OPENMPCC),TRUE)
   defcxxdbgflags+= -fopenmp


### PR DESCRIPTION
I have:
- changed the c++11 flags to c++14 ones. On my cluster the make.defs.local file did not override these and so it caused compile errors in GRChombo.
- added some hopefully useful comments about another flag in case others like me end up looking for bugs in these files - I did not remove the problematic flag (-lsvml) as the errors it causes seem to be specific to particular machines. I will also add relevant notes in the wiki.

EDIT: initially I added a note about template depth in the GNU make defs file, but then I noticed they had increased it to 55, which solves a common compile error I got with GNU.