### PR TITLE
Update SIMD Pragmas

### DIFF
--- a/lib/mk/compiler/Make.defs.GNU
+++ b/lib/mk/compiler/Make.defs.GNU
@@ -68,10 +68,12 @@ endif
   # NOTE: -malign-double causes MPI programs that use pout() to
   # segfault in ~ostream(), so dont use it
 
+  # SIMD pragmas are now OpenMP ones and may want to vectorize even if not
+  # using OpenMP.
 ifeq ($(OPENMPCC),TRUE)
   _cxxbaseflags += -fopenmp
 else
-  _cxxbaseflags += -Wno-unknown-pragmas
+  _cxxbaseflags += -fopenmp-simd -Wno-unknown-pragmas
 endif
 
 defcxxcomflags := -march=native $(_cxxbaseflags)

--- a/lib/mk/compiler/Make.defs.Intel
+++ b/lib/mk/compiler/Make.defs.Intel
@@ -38,11 +38,11 @@ makefiles+=compiler/Make.defs.Intel
 
 getcompilerversion := $(CHOMBO_HOME)/mk/compilerVersion.pl
 
-# '-EP' is different from '-E -P' in icc	
+# '-EP' is different from '-E -P' in icc
 # -C disable stripping out C++ comments, which are valid code in Fortran
 CH_CPP = $(CXX) -EP -C
 
-# Changed c++11 flag into c++14 as required for GRChombo 
+# Changed c++11 flag into c++14 as required for GRChombo
 _cxxbaseflags = -restrict -m64 -std=c++14
 
 cxxdbgflags += -g -Wall -Wextra -pedantic -fstack-protector-all $(_cxxbaseflags)
@@ -58,15 +58,16 @@ fdbgflags += -g -check bounds -check uninit -ftrapuv
 flibflags += -lifport -lifcore -limf -lm -lipgo -lirc -lsvml
 
 # Compile with OpenMP
+# SIMD pragmas are now OpenMP ones and may want to vectorize even if not
+# using OpenMP.
 ifeq ($(OPENMPCC),TRUE)
   cxxoptflags += -qopenmp
   cxxdbgflags += -qopenmp
   foptflags += -qopenmp
   fdbgflags += -qopenmp
 else
-  cxxoptflags += -Wno-unknown-pragmas -diag-disable 3180
-  cxxdbgflags += -Wno-unknown-pragmas -diag-disable 3180
+  cxxoptflags += -qopenmp-simd -Wno-unknown-pragmas -diag-disable 3180
+  cxxdbgflags += -qopenmp-simd -Wno-unknown-pragmas -diag-disable 3180
   foptflags += -Wno-unknown-pragmas -diag-disable 3180
   fdbgflags += -Wno-unknown-pragmas -diag-disable 3180
 endif
-

--- a/lib/mk/compiler/Make.defs.clang++
+++ b/lib/mk/compiler/Make.defs.clang++
@@ -1,4 +1,4 @@
-## This file contains compiler variables for the Apple clang++ compiler   
+## This file contains compiler variables for the Apple clang++ compiler
 
 ## It sets values for the defaults variables ($def*), which will be used
 ## if the calling makefile doesn't set the corresponding variables.
@@ -15,33 +15,34 @@
 
 makefiles+=local/Make.defs.clang++
 
-# Changed c++11 flag into c++14 as required for GRChombo 
+# Changed c++11 flag into c++14 as required for GRChombo
 defcxxdbgflags = -std=c++14 -g -Wall -Wno-overloaded-virtual -Wno-sign-compare
 defcxxoptflags = -std=c++14 -O3 -march=native  -Wno-sign-compare
 
+# SIMD pragmas are now OpenMP ones and may want to vectorize even if not
+# using OpenMP.
 ifeq ($(OPENMPCC),TRUE)
   defcxxdbgflags+= -fopenmp
   defcxxoptflags+= -fopenmp
 else
-  defcxxdbgflags+= -Wno-unknown-pragmas
-  defcxxoptflags+= -Wno-unknown-pragmas
+  defcxxdbgflags+= -fopenmp-simd -Wno-unknown-pragmas
+  defcxxoptflags+= -fopenmp-simd -Wno-unknown-pragmas
 endif
 
 
-CH_CPP = cpp -E -P -C 
+CH_CPP = cpp -E -P -C
 
 fname   := $(notdir $(firstword $(subst -, ,$(FC))))
 
 ifeq ($(fname),gfortran)
-  deffcomflags = -Wno-line-truncation -fno-second-underscore 
+  deffcomflags = -Wno-line-truncation -fno-second-underscore
   # these flags get rid of unused variables warnings. (-Wno-unused-parameter -Wno-unused-variable)
   deffcomflags += -Wno-unused-parameter -Wno-unused-variable
   deffoptflags = -O3 -funroll-loops -march=native
   deffdbgflags = -g -ggdb -Wall -W
   defflibflags  += -lgfortran -lm
 else
-  deffdbgflags = -g 
+  deffdbgflags = -g
   defoptflags = -O2 -march=native
 #  I don't know what library flag you need if this is gfortran
 endif
-

--- a/lib/src/AMRTimeDependent/TimeInterpolatorRK4.cpp
+++ b/lib/src/AMRTimeDependent/TimeInterpolatorRK4.cpp
@@ -243,7 +243,12 @@ void TimeInterpolatorRK4::interpolate(/// interpolated solution on this level co
             const double *const a2 = taylorFab.dataPtr(coeffFirst[2] + comp);
             const double *const a3 = taylorFab.dataPtr(coeffFirst[3] + comp);
 
-            #pragma omp simd simdlen(8)
+            // simdlen(n) clause requires OpenMP 4.5 or greater
+            #if _OPENMP > 201510
+                #pragma omp simd simdlen(8)
+            #else
+                #pragma omp simd
+            #endif
             for (int i = i_start; i < i_end; ++i)
               {
                 U[i] = a0[i] + a_timeInterpCoeff * (a1[i] + a_timeInterpCoeff

--- a/lib/src/AMRTimeDependent/TimeInterpolatorRK4.cpp
+++ b/lib/src/AMRTimeDependent/TimeInterpolatorRK4.cpp
@@ -243,12 +243,7 @@ void TimeInterpolatorRK4::interpolate(/// interpolated solution on this level co
             const double *const a2 = taylorFab.dataPtr(coeffFirst[2] + comp);
             const double *const a3 = taylorFab.dataPtr(coeffFirst[3] + comp);
 
-            // simdlen(n) clause requires OpenMP 4.5 or greater
-            #if _OPENMP > 201510
-                #pragma omp simd simdlen(8)
-            #else
-                #pragma omp simd
-            #endif
+            #pragma omp simd
             for (int i = i_start; i < i_end; ++i)
               {
                 U[i] = a0[i] + a_timeInterpCoeff * (a1[i] + a_timeInterpCoeff

--- a/lib/src/AMRTimeDependent/TimeInterpolatorRK4.cpp
+++ b/lib/src/AMRTimeDependent/TimeInterpolatorRK4.cpp
@@ -243,7 +243,7 @@ void TimeInterpolatorRK4::interpolate(/// interpolated solution on this level co
             const double *const a2 = taylorFab.dataPtr(coeffFirst[2] + comp);
             const double *const a3 = taylorFab.dataPtr(coeffFirst[3] + comp);
 
-            #pragma omp simd
+            #pragma omp simd simdlen(8)
             for (int i = i_start; i < i_end; ++i)
               {
                 U[i] = a0[i] + a_timeInterpCoeff * (a1[i] + a_timeInterpCoeff

--- a/lib/src/AMRTimeDependent/TimeInterpolatorRK4.cpp
+++ b/lib/src/AMRTimeDependent/TimeInterpolatorRK4.cpp
@@ -243,7 +243,7 @@ void TimeInterpolatorRK4::interpolate(/// interpolated solution on this level co
             const double *const a2 = taylorFab.dataPtr(coeffFirst[2] + comp);
             const double *const a3 = taylorFab.dataPtr(coeffFirst[3] + comp);
 
-            #pragma simd vectorlengthfor(double)
+            #pragma omp simd
             for (int i = i_start; i < i_end; ++i)
               {
                 U[i] = a0[i] + a_timeInterpCoeff * (a1[i] + a_timeInterpCoeff

--- a/lib/src/BoxTools/BaseFabImplem.H
+++ b/lib/src/BoxTools/BaseFabImplem.H
@@ -676,7 +676,12 @@ inline void BaseFab<double>::performCopy(const BaseFab<double>& a_src,
             double *const dest = dataPtr(a_destcomp + comp);
             const double *const src = a_src.dataPtr(a_srccomp + comp);
 
-            #pragma omp simd simdlen(8)
+            // simdlen(n) clause requires OpenMP 4.5 or greater
+            #if _OPENMP > 201510
+                #pragma omp simd simdlen(8)
+            #else
+                #pragma omp simd
+            #endif
             for (int i = i_start; i < i_end; ++i)
               {
                 dest[i] = src[i];

--- a/lib/src/BoxTools/BaseFabImplem.H
+++ b/lib/src/BoxTools/BaseFabImplem.H
@@ -676,12 +676,7 @@ inline void BaseFab<double>::performCopy(const BaseFab<double>& a_src,
             double *const dest = dataPtr(a_destcomp + comp);
             const double *const src = a_src.dataPtr(a_srccomp + comp);
 
-            // simdlen(n) clause requires OpenMP 4.5 or greater
-            #if _OPENMP > 201510
-                #pragma omp simd simdlen(8)
-            #else
-                #pragma omp simd
-            #endif
+            #pragma omp simd
             for (int i = i_start; i < i_end; ++i)
               {
                 dest[i] = src[i];

--- a/lib/src/BoxTools/BaseFabImplem.H
+++ b/lib/src/BoxTools/BaseFabImplem.H
@@ -676,7 +676,7 @@ inline void BaseFab<double>::performCopy(const BaseFab<double>& a_src,
             double *const dest = dataPtr(a_destcomp + comp);
             const double *const src = a_src.dataPtr(a_srccomp + comp);
 
-            #pragma omp simd
+            #pragma omp simd simdlen(8)
             for (int i = i_start; i < i_end; ++i)
               {
                 dest[i] = src[i];

--- a/lib/src/BoxTools/BaseFabImplem.H
+++ b/lib/src/BoxTools/BaseFabImplem.H
@@ -676,7 +676,7 @@ inline void BaseFab<double>::performCopy(const BaseFab<double>& a_src,
             double *const dest = dataPtr(a_destcomp + comp);
             const double *const src = a_src.dataPtr(a_srccomp + comp);
 
-            #pragma simd vectorlengthfor(double)
+            #pragma omp simd
             for (int i = i_start; i < i_end; ++i)
               {
                 dest[i] = src[i];


### PR DESCRIPTION
I have updated the old Intel Cilk Plus SIMD pragmas to new (and more portable) OpenMP SIMD pragmas. This is because the former will soon be deprecated by most major compilers (see [this page](https://software.intel.com/en-us/articles/migrate-your-application-to-use-openmp-or-intelr-tbb-instead-of-intelr-cilktm-plus) on the Intel website). Currently I have found the following:
- Intel Compiler: As of v18.3, icpc gives a warning that these old-style pragmas will be deprecated in a future release but they do still work.
- GCC: Deprecated in v8.1. Currently gives a warnings about unknown pragmas.

I have verified by looking at compiler reports (Intel compiler only) that the relevant loops are still being vectorized. Unfortunately the Intel Cilk Plus SIMD pragma clause `vectorlengthfor(double)` no longer exists with OpenMP SIMD so I have replaced it with `simdlen(8)`. This is only a target for the compiler and it should still compile fine on architectures with smaller vector widths.

Since the new pragmas require OpenMP, I have also added additional flags to the Make.defs.\<compiler\> for GCC, Intel and Clang which will allow vectorization using these directives even if compiling without OpenMP.