### PR TITLE
Add hook for post proc tools after restart

### DIFF
--- a/lib/src/AMRTimeDependent/AMR.cpp
+++ b/lib/src/AMRTimeDependent/AMR.cpp
@@ -697,6 +697,12 @@ void AMR::setupForRestart(HDF5Handle& a_handle)
       m_amrlevels[level]->initialGrid(Vector<Box>());
       m_amrlevels[level]->initialData();
     }
+
+  // add a hook here for use in postprocessing the files
+  for (int level = 0; level <= m_finest_level; ++level)
+    {
+      m_amrlevels[level]->postRestart();
+    }
 }
 #endif
 //-----------------------------------------------------------------------

--- a/lib/src/AMRTimeDependent/AMRLevel.H
+++ b/lib/src/AMRTimeDependent/AMRLevel.H
@@ -293,6 +293,15 @@ public:
 
   ///
   /**
+     Run postRestart if we want to act on data after setup for restart from checkpoints
+  */
+  virtual
+    void postRestart ()
+    {
+    }
+
+  ///
+  /**
      Reads checkpoint header.
 
      This is a pure virtual function and  MUST be defined in the derived


### PR DESCRIPTION
- This hook allows us to do operations on the hdf5 files after opening them for restart, without calling amr.run().
- A corresponding amendment will also be made in GRChombo GRAMRLevel().
- This should not break old code, as it simply adds an additional virtual function which by default does nothing.