### PR TITLE
Fortran preprocessing on ifort 18.0 and higher

### DIFF
--- a/lib/mk/Make.printVariables
+++ b/lib/mk/Make.printVariables
@@ -91,7 +91,7 @@ defs:
 	@echo "PROFILE=$(PROFILE)"
 	@echo "MPI=$(MPI)"
 	@echo "MPICXX=$(MPICXX)"
-        @echo "OPENMPCC=$(OPENMPCC)"
+  @echo "OPENMPCC=$(OPENMPCC)"
 	@echo "ROSE=$(ROSE)"
 	@echo "ROSECC=$(ROSECC)"
 	@echo "ROSEINCFLAGS=$(ROSEINCFLAGS)"

--- a/lib/mk/Make.printVariables
+++ b/lib/mk/Make.printVariables
@@ -91,7 +91,7 @@ defs:
 	@echo "PROFILE=$(PROFILE)"
 	@echo "MPI=$(MPI)"
 	@echo "MPICXX=$(MPICXX)"
-  @echo "OPENMPCC=$(OPENMPCC)"
+	@echo "OPENMPCC=$(OPENMPCC)"
 	@echo "ROSE=$(ROSE)"
 	@echo "ROSECC=$(ROSECC)"
 	@echo "ROSEINCFLAGS=$(ROSEINCFLAGS)"

--- a/lib/mk/compiler/Make.defs.Intel
+++ b/lib/mk/compiler/Make.defs.Intel
@@ -34,7 +34,11 @@
 
 makefiles+=compiler/Make.defs.Intel
 
-
+# I don't think the compilerVersion perl script works for newer (or perhaps any)
+# intel compilers but the -dumpversion flag should be available on any relevant
+# version
+_icpcfullver  := $(subst ., ,$(shell $(CXX) -dumpversion))
+_icpcmajorver := $(word 1,$(_icpcfullver))
 
 getcompilerversion := $(CHOMBO_HOME)/mk/compilerVersion.pl
 
@@ -47,6 +51,13 @@ _cxxbaseflags = -restrict -m64 -std=c++14
 
 cxxdbgflags += -g -Wall -Wextra -pedantic -fstack-protector-all $(_cxxbaseflags)
 cxxoptflags += -O3 -m64 -qopt-multi-version-aggressive $(_cxxbaseflags)
+
+# For ifort v18.0 and above need this extra flag to preprocess correctly
+# Note that this assumes your version of icpc is the same as ifort like any
+# sane configuration should be
+ifeq (0,$(shell test $(_icpcmajorver) -ge 18 ; echo $$?))
+	deffcomflags += -fpp
+endif
 
 defldflags = -static-intel
 


### PR DESCRIPTION
Recent versions of the Intel Compilers (I think v18.0 and above) have had issues with preprocessed files. So far, this has been fixed by adding the `-fpp` flag (or similar) in Make.defs.local but this PR means it will be added automatically if the version is >= 18. I have tested this using v19.0.3 and v17.0.8 on csd3 and the libraries compile fine.