### PR TITLE
Fix KNL compilation with GCC

### DIFF
--- a/lib/mk/compiler/Make.defs.GNU
+++ b/lib/mk/compiler/Make.defs.GNU
@@ -76,7 +76,7 @@ else
   _cxxbaseflags += -fopenmp-simd -Wno-unknown-pragmas
 endif
 
-defcxxcomflags := -march=native $(_cxxbaseflags)
+defcxxcomflags := $(_cxxbaseflags)
 defcxxoptflags := $(defcxxcomflags) -O3
 defcxxdbgflags := $(defcxxcomflags) -g -pedantic -Wall
 


### PR DESCRIPTION
The `-march=native` flag in Make.defs.GNU makes it impossible to compile KNL code on a non-KNL processor (such as skylake) so I have removed it. This can [and should] be set manually.