### PR TITLE
Add AMR::run hook to stop evolution

### DIFF
--- a/lib/src/AMRTimeDependent/AMR.H
+++ b/lib/src/AMRTimeDependent/AMR.H
@@ -190,6 +190,10 @@ public:
   //! Tells AMR to check each level for steady state and stop if we get there
   void checkForSteadyState(bool a_steadyState);
 
+  //! Tells AMR whether to allow AMRLevels to stop the evolution at the end of a
+  //! coarse timestep
+  void allowEvolutionStop(bool a_allow_evolution_stop);
+
   //! Tells AMR to write plot files after every \a a_plot_period time units.
   void plotPeriod(Real a_plot_period);
 
@@ -447,6 +451,7 @@ protected:
   Real m_dt_tolerance_factor;
   Real m_fixedDt;
   bool              m_checkForSteadyState;
+  bool              m_allow_evolution_stop;
   bool              m_isDefined;
   bool              m_isSetUp;
   Vector<AMRLevel*> m_amrlevels;

--- a/lib/src/AMRTimeDependent/AMR.cpp
+++ b/lib/src/AMRTimeDependent/AMR.cpp
@@ -910,9 +910,6 @@ void AMR::run(Real a_max_time, int a_max_step)
         }
       if (m_allow_evolution_stop)
         {
-#ifdef CH_MPI
-          MPI_Barrier(Chombo_MPI::comm);
-#endif
           stop_evolution = m_amrlevels[0]->stopEvolution();
         }
       if (stop_evolution)

--- a/lib/src/AMRTimeDependent/AMR.cpp
+++ b/lib/src/AMRTimeDependent/AMR.cpp
@@ -908,13 +908,20 @@ void AMR::run(Real a_max_time, int a_max_step)
             }
           break;
         }
+      bool write_checkpoint = false;
       if (m_allow_evolution_stop)
         {
-          stop_evolution = m_amrlevels[0]->stopEvolution();
+          stop_evolution = m_amrlevels[0]->stopEvolution(write_checkpoint);
         }
       if (stop_evolution)
         {
           pout() << "AMR: evolution stopped" << endl;
+          if ((m_checkpoint_interval > 0) && write_checkpoint &&
+              (m_lastcheck_step != m_cur_step))
+            {
+              pout() << "writing checkpoint file" << endl;
+              writeCheckpointFile();
+            }
           break;
         }
     }

--- a/lib/src/AMRTimeDependent/AMR.cpp
+++ b/lib/src/AMRTimeDependent/AMR.cpp
@@ -908,7 +908,7 @@ void AMR::run(Real a_max_time, int a_max_step)
             }
           break;
         }
-      bool write_checkpoint = false;
+      bool write_checkpoint = true;
       if (m_allow_evolution_stop)
         {
           stop_evolution = m_amrlevels[0]->stopEvolution(write_checkpoint);

--- a/lib/src/AMRTimeDependent/AMRLevel.H
+++ b/lib/src/AMRTimeDependent/AMRLevel.H
@@ -122,7 +122,18 @@ public:
   {
     return false;
   }
-    
+
+   ///
+  /**
+     Return true on the coarsest level to stop the evolution
+     Default version always returns false.
+   */
+  virtual
+  bool stopEvolution()
+  {
+    return false;
+  }
+
   ///
   /**
      Things to do after advancing this level by one time step.

--- a/lib/src/AMRTimeDependent/AMRLevel.H
+++ b/lib/src/AMRTimeDependent/AMRLevel.H
@@ -132,6 +132,7 @@ public:
   virtual
   bool stopEvolution(bool& a_write_checkpoint)
   {
+    a_write_checkpoint = true;
     return false;
   }
 

--- a/lib/src/AMRTimeDependent/AMRLevel.H
+++ b/lib/src/AMRTimeDependent/AMRLevel.H
@@ -126,10 +126,11 @@ public:
    ///
   /**
      Return true on the coarsest level to stop the evolution
+     Can also ask whether to write a checkpoint or not
      Default version always returns false.
    */
   virtual
-  bool stopEvolution()
+  bool stopEvolution(bool& a_write_checkpoint)
   {
     return false;
   }


### PR DESCRIPTION
This adds a hook in the form of `AMRLevel::stopEvolution` which will break the loop in `AMR::run` at the end of a coarse timestep if true is returned on the coarsest level. This is quite similar to the existing `convergedToSteadyState` hook except for the following:
- `convergedToSteadyState` checks every `AMRLevel`. 
- `convergedToSteadyState` always writes a checkpoint and plot file (assuming that `checkpoint_interval > 0`) whereas `stopEvolution` by default does not but can do so by modifying its single argument.
- A different message is printed to the pout files.

Note that this feature is disabled by default but can be enabled by calling `AMR::allowEvolutionStop(true)`.