### PR TITLE
Amendments to fix mac os compile bugs

### DIFF
--- a/lib/mk/Make.defs
+++ b/lib/mk/Make.defs
@@ -217,6 +217,12 @@ endif
 # GNU compilers with version attached e.g. g++-9
 ifeq ($(findstring g++-, $(cxxname)), g++-)
   include $(CHOMBO_HOME)/mk/compiler/Make.defs.GNU
+else
+  # GNU Fortran95 compiler in gcc e.g. gfortran-9
+  ifeq ($(findstring gfortran-, $(fname)), gfortran-)
+    include $(CHOMBO_HOME)/mk/compiler/Make.defs.GNU
+  endif
+
 endif
 
 # Intel compiler

--- a/lib/mk/Make.defs
+++ b/lib/mk/Make.defs
@@ -214,6 +214,12 @@ else
   endif
 endif
 
+# GNU compilers with version attached e.g. g++-9
+ifeq ($(findstring g++-, $(cxxname)), g++-)
+  include $(CHOMBO_HOME)/mk/compiler/Make.defs.GNU
+endif
+
+# Intel compiler
 ifeq ($(cxxname),icpc)
  include $(CHOMBO_HOME)/mk/compiler/Make.defs.Intel
 endif


### PR DESCRIPTION
The --preserve-timestamps flag does not exist on the mac posix system. I've reverted it to -p but perhaps @draenog  can think of a good fix for this?

I have also made the make defs file recognise the g++-9 compiler as a gcc compiler, so we don't have to manually add flags.

