### PR TITLE
Don't use cp option not present in macOS

### DIFF
--- a/lib/GNUmakefile
+++ b/lib/GNUmakefile
@@ -253,12 +253,12 @@ include: $(CHOMBO_HOME)/include  $(MULTIDIM_INCLUDE_DIR)
 ifneq ($(wildcard $(CHOMBO_HOME)/include/*.H),)
 	$(QUIET)chmod -R u+w $(CHOMBO_HOME)/include
 endif
-	$(QUIET)$(foreach d,$(lib_targets),cp --preserve=timestamps $(CHOMBO_HOME)/src/$(d)/*.H $(CHOMBO_HOME)/include ;)
+	$(QUIET)$(foreach d,$(lib_targets),install -p $(CHOMBO_HOME)/src/$(d)/*.H $(CHOMBO_HOME)/include ;)
 #build multidim headers if necessary -- hardwire to build DIM=1->6
 ifeq ($(MULTIDIM),TRUE)
 	$(QUIET)cat $(foreach d,$(lib_targets), $(CHOMBO_HOME)/src/$(d)/multidim/dim-independent-headers.txt)> $(CHOMBO_HOME)/include/multidim/dim-independent-headers.txt
 	$(QUIET)$(CHOMBO_HOME)/util/multidim/make_headers.sh $(CHOMBO_HOME)/include $(CHOMBO_HOME)/include 1 6
-	$(QUIET)cp --preserve=timestamps $(CHOMBO_HOME)/src/MultiDim/*.H.transdim $(CHOMBO_HOME)/include/multidim
+	$(QUIET)install -p $(CHOMBO_HOME)/src/MultiDim/*.H.transdim $(CHOMBO_HOME)/include/multidim
 	$(QUIET)find $(CHOMBO_HOME)/include/multidim -name '*.H*' -exec chmod u-w {} \;
 endif
 	$(QUIET)find $(CHOMBO_HOME)/include -name '*.H' -exec chmod u-w {} \;

--- a/lib/mk/Make.rules
+++ b/lib/mk/Make.rules
@@ -368,12 +368,12 @@ include: $(CHOMBO_HOME)/include $(MULTIDIM_INCLUDE_DIR)
 ifneq ($(wildcard $(CHOMBO_HOME)/include/*.H),)
 	$(QUIET)chmod -R a+w $(CHOMBO_HOME)/include
 endif
-	$(QUIET)cp --preserve=timestamps $(CHOMBO_HOME)/src/*/*.H $(CHOMBO_HOME)/include
+	$(QUIET)install -p $(CHOMBO_HOME)/src/*/*.H $(CHOMBO_HOME)/include
 #build multidim headers if necessary -- build DIM=1->6
 ifeq ($(MULTIDIM),TRUE)
 	$(QUIET)cat $(CHOMBO_HOME)/src/*/multidim/dim-independent-headers.txt > $(CHOMBO_HOME)/include/multidim/dim-independent-headers.txt
 	$(QUIET)$(CHOMBO_HOME)/util/multidim/make_headers.sh $(CHOMBO_HOME)/include $(CHOMBO_HOME)/include 1 6
-	$(QUIET)cp --preserve=timestamps $(CHOMBO_HOME)/src/MultiDim/*.H.transdim $(CHOMBO_HOME)/include/multidim
+	$(QUIET)install -p $(CHOMBO_HOME)/src/MultiDim/*.H.transdim $(CHOMBO_HOME)/include/multidim
 	$(QUIET)find $(CHOMBO_HOME)/include/multidim -name '*.H*' -exec chmod u-w {} \;
 endif
 	$(QUIET)find $(CHOMBO_HOME)/include -name '*.H' -exec chmod u-w {} \;


### PR DESCRIPTION
per @draenog : 
cp version shipped with macOS does not have --preserve=timestamp. Replace
it with more portable 'install -p'.

per me : 
This option works for my mac OS and also for the CSD3 system where the cp -p flag did not. So I'm happy!