### PR TITLE
Add support for LLVM based compilers

### DIFF
--- a/lib/mk/Make.defs
+++ b/lib/mk/Make.defs
@@ -283,6 +283,11 @@ ifeq ($(findstring Intel,$(cxxname)),Intel)
   cxxname:=clang++
 endif
 
+# Cray LLVM based compiler
+ifeq ($(findstring Cray,$(cxxname)),Cray)
+  cxxname:=clang++
+endif
+
 # Apple clang++ compiler
 ifeq ($(findstring clang,$(cxxname)),clang)
   include $(CHOMBO_HOME)/mk/compiler/Make.defs.clang++

--- a/lib/mk/Make.defs
+++ b/lib/mk/Make.defs
@@ -278,8 +278,13 @@ ifeq ($(cxxname),Apple)
   cxxname:=clang++
 endif 
 
+# Intel oneAPI compiler --version sometimes has Intel in the first word
+ifeq ($(findstring Intel,$(cxxname)),Intel)
+  cxxname:=clang++
+endif
+
 # Apple clang++ compiler
-ifeq ($(cxxname),clang++)
+ifeq ($(findstring clang,$(cxxname)),clang)
   include $(CHOMBO_HOME)/mk/compiler/Make.defs.clang++
 endif
 ## Finally, set the compiler variables to the defaults if they aren't set.

--- a/lib/mk/Make.defs.defaults
+++ b/lib/mk/Make.defs.defaults
@@ -142,13 +142,13 @@ ifeq ($(PIC),TRUE)
 endif
 
 # these usually can be used without change
-CH_AR=ar r
+CH_AR?=ar r
 CH_CPP?=cpp -E -P
 DOXYGEN?=doxygen
 # Note: if $(LD) is blank, $(CXX) or $(MPICXX) is used to link
 LD=
 PERL=perl
-RANLIB=ranlib#  #set this to 'echo' for systems that dont have ranlib
+RANLIB?=ranlib#  #set this to 'echo' for systems that dont have ranlib
 PROF=gprof
 
 # Rose translator (defined here for graceful failure)

--- a/lib/mk/compiler/Make.defs.clang++
+++ b/lib/mk/compiler/Make.defs.clang++
@@ -53,8 +53,13 @@ ifeq ($(fname),gfortran)
   deffoptflags = -O3 -funroll-loops -march=native
   deffdbgflags = -g -ggdb -Wall -W
   defflibflags  += -lgfortran -lm
+else ifeq ($(fname),$(filter $(fname),ifort ifx))
+  # Default flags for the Intel Fortran compiler
+  deffoptflags = -O3 -xHost
+  deffdbgflags = -g -check bounds -check uninit -ftrapuv
+  defflibflags += -lifcore -lifport -limf
 else
   deffdbgflags = -g
   defoptflags = -O2 -march=native
-#  I don't know what library flag you need if this is gfortran
+#  I don't know what library flag you need if this is not gfortran or ifort
 endif

--- a/lib/mk/compiler/Make.defs.clang++
+++ b/lib/mk/compiler/Make.defs.clang++
@@ -16,18 +16,18 @@
 makefiles+=local/Make.defs.clang++
 
 # Changed c++11 flag into c++14 as required for GRChombo
-defcxxdbgflags = -std=c++14 -g -Wall -Wno-overloaded-virtual -Wno-sign-compare
-defcxxoptflags = -std=c++14 -ffast-math -march=native -Rpass=loop-vectorize -Wno-sign-compare
+_cxxbaseflags = -std=c++14 -Wno-sign-compare
 
 # SIMD pragmas are now OpenMP ones and may want to vectorize even if not
 # using OpenMP.
 ifeq ($(OPENMPCC),TRUE)
-  defcxxdbgflags+= -fopenmp
-  defcxxoptflags+= -fopenmp
+  _cxxbaseflags += -fopenmp
 else
-  defcxxdbgflags+= -fopenmp-simd -Wno-unknown-pragmas
-  defcxxoptflags+= -fopenmp-simd -Wno-unknown-pragmas
+  _cxxbaseflags += -fopenmp-simd -Wno-unknown-pragmas
 endif
+defcxxcomflags := $(_cxxbaseflags)
+defcxxoptflags := $(defcxxcomflags) -O3 -march=native
+defcxxdbgflags := $(defcxxcomflags) -g -Wall -Wno-overloaded-virtual -Wno-missing-braces
 
 
 CH_CPP = cpp -E -P 

--- a/lib/mk/compiler/Make.defs.clang++
+++ b/lib/mk/compiler/Make.defs.clang++
@@ -18,12 +18,24 @@ makefiles+=local/Make.defs.clang++
 # Changed c++11 flag into c++14 as required for GRChombo
 _cxxbaseflags = -std=c++14 -Wno-sign-compare
 
+# Need to test for Intel DPC++/C++ compiler for OpenMP flags
+clangcxxname := $(firstword $(shell $(CXX) --version))
+
 # SIMD pragmas are now OpenMP ones and may want to vectorize even if not
 # using OpenMP.
 ifeq ($(OPENMPCC),TRUE)
-  _cxxbaseflags += -fopenmp
+  ifeq ($(findstring Intel,$(clangcxxname)),Intel)
+    _cxxbaseflags += -fiopenmp # Use Intel OpenMP
+  else
+    _cxxbaseflags += -fopenmp
+  endif
 else
-  _cxxbaseflags += -fopenmp-simd -Wno-unknown-pragmas
+  ifeq ($(findstring Intel,$(clangcxxname)),Intel)
+    _cxxbaseflags += -fiopenmp-simd # Use Intel OpenMP SIMD
+  else
+    _cxxbaseflags += -fopenmp-simd
+  endif
+  _cxxbaseflags += -Wno-unknown-pragmas
 endif
 defcxxcomflags := $(_cxxbaseflags)
 defcxxoptflags := $(defcxxcomflags) -O3 -march=native

--- a/lib/src/BaseTools/LAPACKMatrix.H
+++ b/lib/src/BaseTools/LAPACKMatrix.H
@@ -36,7 +36,7 @@ public:
       m_ncol = ncol;
       if(m_data != nullptr) 
       {
-        delete m_data;
+        delete[] m_data;
       }
       m_data =new Real[m_nrow*m_ncol];
     }

--- a/lib/src/BoxTools/IntVect.H
+++ b/lib/src/BoxTools/IntVect.H
@@ -696,7 +696,13 @@ protected:
 };
 #include "NamespaceFooter.H"
 
-namespace std { template <> inline bool less<CH_XD::IntVect>::operator()(const CH_XD::IntVect& a, const CH_XD::IntVect& b) const { return a.lexLT(b);}
+namespace std { template <>
+#ifdef __clang__ // Clang and GCC handle this differently. The C++14 standard
+constexpr        // says this specialization of std::less should be constexpr
+#else            // but GCC does not like this as lexLT is not constexpr. We
+inline           // could make lexLT and all its called functions constexpr but
+#endif           // this would break compilation on old GCC versions (e.g. v6)
+bool less<CH_XD::IntVect>::operator()(const CH_XD::IntVect& a, const CH_XD::IntVect& b) const { return a.lexLT(b);}
 }
 #include "BaseNamespaceHeader.H"
 


### PR DESCRIPTION
Since many new compilers are based on the LLVM infrastructure (e.g. Clang++, Intel oneAPI (icpx), AMD (AOCC), Cray, etc.) it is important to add support for them.

This fixes #28 and a few other minor warnings. The compiler specific Make.defs.clang++ has been slightly rewritten to be more consistent with Make.defs.GNU and Make.defs has been updated to include these clang++ flags for more LLVM compilers.