### PR TITLE
Add support for AMD LLVM based compilers (AOCC)

### DIFF
--- a/lib/mk/Make.defs
+++ b/lib/mk/Make.defs
@@ -288,6 +288,11 @@ ifeq ($(findstring Cray,$(cxxname)),Cray)
   cxxname:=clang++
 endif
 
+# AMD Optimizing Compiler (AOCC)  
+ifeq ($(findstring AMD,$(cxxname)),AMD)
+  cxxname:=clang++
+endif
+
 # Apple clang++ compiler
 ifeq ($(findstring clang,$(cxxname)),clang)
   include $(CHOMBO_HOME)/mk/compiler/Make.defs.clang++

--- a/lib/mk/compiler/Make.defs.clang++
+++ b/lib/mk/compiler/Make.defs.clang++
@@ -58,8 +58,17 @@ else ifeq ($(fname),$(filter $(fname),ifort ifx))
   deffoptflags = -O3 -xHost
   deffdbgflags = -g -check bounds -check uninit -ftrapuv
   defflibflags += -lifcore -lifport -limf
+else ifeq ($(fname),flang)
+  # Default flags for Classic Flang (e.g. AMD AOCC Fortran compiler)
+  # Note that the name flang is also used by other Fortran compilers for which
+  # these defaults may not work.
+  deffcomflags = -Wno-unused-parameter -Wno-unused-variable
+  deffoptflags = -O3 -march-native
+  deffdbgflags = -g -Wall
+  defflibflags += -lflang -lpgmath
 else
   deffdbgflags = -g
   defoptflags = -O2 -march=native
-#  I don't know what library flag you need if this is not gfortran or ifort
+#  I don't know what library flag you need if this is not gfortran, flang or 
+#  ifort/ifx
 endif


### PR DESCRIPTION
This just modifies the Chombo makefiles so that they recognise the AMD LLVM based compilers and sets the default flags to correctly link the Fortran libraries. I have tested this with the `aocc/3.1.0/uj2bmp` module on [DiAL3](https://dial3-docs.dirac.ac.uk/).