### PR TITLE
Add aligned memory makefile variable

### DIFF
--- a/lib/mk/Make.defs.defaults
+++ b/lib/mk/Make.defs.defaults
@@ -102,6 +102,7 @@ LDFLAGS?=
 
 # Chombo optional features
 USE_64?=TRUE#        #64bit pointers
+USE_ALIGNED_MEMORY?=FALSE  #Allocate aligned memory
 USE_MT?=FALSE#         #memory tracking
 # USE_SETVAL?=TRUE#     #initialize FAB data
 USE_COMPLEX?=TRUE#    #type for complex numbers

--- a/lib/mk/Make.defs.local.template
+++ b/lib/mk/Make.defs.local.template
@@ -42,19 +42,20 @@ makefiles+=Make.defs.local
 
 # Variables for optional features that don't affect filenames:
 
-#  USE_64          : if TRUE, use 64bit pointers on systems where 32bits is the default
-#  USE_COMPLEX     : if TRUE, enable the 'Complex' type
-#                    (default is TRUE, disable only if compiler doesn't allow it)
-#  USE_EB          : if TRUE, build Chombo Embedded Boundary code
-#  USE_CCSE        : if TRUE, build CCSE mglib and supporting code into one lib
-#  USE_HDF         : if TRUE, use the HDF5 library
-#   HDFINCFLAGS    : cpp options (-I*) for HDF5 include files
-#   HDFLIBFLAGS    : link options (-L* -l*) for HDF5 library files
-#   HDFMPIINCFLAGS : cpp options (-I*) for parallel HDF5 include files
-#   HDFMPILIBFLAGS : link options (-L* -l*) for parallel HDF5 library files
-#  USE_MF          : if TRUE, build Chombo MultiFluid code (requires USE_EB=TRUE)
-#  USE_MT          : if TRUE, enable Chombo memory tracking
-#  USE_SETVAL      : (TRUE,FALSE) use setVal to initialize all BaseFab<Real>
+#  USE_64             : if TRUE, use 64bit pointers on systems where 32bits is the default
+#  USE_ALIGNED_MEMORY : if TRUE, allocate memory using posix_memalign
+#  USE_COMPLEX        : if TRUE, enable the 'Complex' type
+#                       (default is TRUE, disable only if compiler doesn't allow it)
+#  USE_EB             : if TRUE, build Chombo Embedded Boundary code
+#  USE_CCSE           : if TRUE, build CCSE mglib and supporting code into one lib
+#  USE_HDF            : if TRUE, use the HDF5 library
+#   HDFINCFLAGS       : cpp options (-I*) for HDF5 include files
+#   HDFLIBFLAGS       : link options (-L* -l*) for HDF5 library files
+#   HDFMPIINCFLAGS    : cpp options (-I*) for parallel HDF5 include files
+#   HDFMPILIBFLAGS    : link options (-L* -l*) for parallel HDF5 library files
+#  USE_MF             : if TRUE, build Chombo MultiFluid code (requires USE_EB=TRUE)
+#  USE_MT             : if TRUE, enable Chombo memory tracking
+#  USE_SETVAL         : (TRUE,FALSE) use setVal to initialize all BaseFab<Real>
 
 # These variables are system-dependent but usually dont have to be changed:
 
@@ -104,52 +105,53 @@ makefiles+=Make.defs.local
 ## Override the default values here
 
 ## Configuration variables
-#DIM           =
-#DEBUG         =
-#OPT           =
-#PRECISION     =
-#PROFILE       =
-#CXX           =
-#FC            =
-#MPI           =
+#DIM                =
+#DEBUG              =
+#OPT                =
+#PRECISION          =
+#PROFILE            =
+#CXX                =
+#FC                 =
+#MPI                =
 ## Note: don't set the MPICXX variable if you don't have MPI installed
-#MPICXX        =
-#OBJMODEL      =
-#XTRACONFIG    =
+#MPICXX             =
+#OBJMODEL           =
+#XTRACONFIG         =
 ## Optional features
-#USE_64        =
-#USE_COMPLEX   =
-#USE_EB        =
-#USE_CCSE      =
-#USE_HDF       =
-#HDFINCFLAGS   = -I<hdf_serial_dir>/include
-#HDFLIBFLAGS   = -L<hdf_serial_dir>/lib -lhdf5 -lz
+#USE_64             =
+#USE_ALIGNED_MEMORY =
+#USE_COMPLEX        =
+#USE_EB             =
+#USE_CCSE           =
+#USE_HDF            =
+#HDFINCFLAGS        = -I<hdf_serial_dir>/include
+#HDFLIBFLAGS        = -L<hdf_serial_dir>/lib -lhdf5 -lz
 ## Note: don't set the HDFMPI* variables if you don't have parallel HDF installed
-#HDFMPIINCFLAGS= -I<hdf_parallel_dir>/include
-#HDFMPILIBFLAGS= -L<hdf_parallel_dir>/lib -lhdf5 -lz
-#USE_MF        =
-#USE_MT        =
-#USE_SETVAL    =
-#CH_AR         =
-#CH_CPP        =
-#DOXYGEN       =
-#LD            =
-#PERL          =
-#RANLIB        =
-#cppdbgflags   =
-#cppoptflags   =
-#cxxcppflags   =
-#cxxdbgflags   =
-#cxxoptflags   =
-#cxxprofflags  =
-#fcppflags     =
-#fdbgflags     =
-#foptflags     =
-#fprofflags    =
-#flibflags     =
-#lddbgflags    =
-#ldoptflags    =
-#ldprofflags   =
-#syslibflags   =
+#HDFMPIINCFLAGS     = -I<hdf_parallel_dir>/include
+#HDFMPILIBFLAGS     = -L<hdf_parallel_dir>/lib -lhdf5 -lz
+#USE_MF             =
+#USE_MT             =
+#USE_SETVAL         =
+#CH_AR              =
+#CH_CPP             =
+#DOXYGEN            =
+#LD                 =
+#PERL               =
+#RANLIB             =
+#cppdbgflags        =
+#cppoptflags        =
+#cxxcppflags        =
+#cxxdbgflags        =
+#cxxoptflags        =
+#cxxprofflags       =
+#fcppflags          =
+#fdbgflags          =
+#foptflags          =
+#fprofflags         =
+#flibflags          =
+#lddbgflags         =
+#ldoptflags         =
+#ldprofflags        =
+#syslibflags        =
 
 #end  -- dont change this line

--- a/lib/mk/Make.printVariables
+++ b/lib/mk/Make.printVariables
@@ -117,6 +117,7 @@ defs:
 	@echo "RUN=$(RUN)"
 	@echo "RUNFLAGS=$(RUNFLAGS)"
 	@echo "USE_64=$(USE_64)"
+	@echo "USE_ALIGNED_MEMORY=$(USE_ALIGNED_MEMORY)"
 	@echo "USE_COMPLEX=$(USE_COMPLEX)"
 	@echo "USE_EB=$(USE_EB)"
 	@echo "USE_FFTW=$(USE_FFTW)"

--- a/lib/mk/Make.rules
+++ b/lib/mk/Make.rules
@@ -120,6 +120,7 @@ export USE_4D
 export USE_5D
 export USE_6D
 export USE_64
+export USE_ALIGNED_MEMORY
 export USE_CCSE
 export USE_COMPLEX
 export USE_EB
@@ -258,6 +259,7 @@ $(subst FALSE,,$(subst TRUE,-DCH_USE_MEMORY_TRACKING,$(USE_MT)))\
 $(subst FALSE,,$(subst TRUE,-DCH_COUNT_FLOPS,$(COUNT_FLOPS)))\
 $(subst FALSE,-DCH_NTIMER,$(subst TRUE,,$(USE_TIMER)))\
 $(subst FALSE,,$(subst TRUE,-DCH_USE_64,$(USE_64)))\
+$(subst FALSE,,$(subst TRUE,-DCH_USE_ALIGNED_MEMORY,$(USE_ALIGNED_MEMORY)))\
 $(subst DOUBLE,-DCH_USE_DOUBLE,$(subst FLOAT,-DCH_USE_FLOAT,$(PRECISION)))\
 $(subst FALSE,,$(subst TRUE,-DCH_USE_HDF5 $(subst FALSE,$(HDFINCFLAGS),$(subst TRUE,$(HDFMPIINCFLAGS),$(MPI))),$(USE_HDF)))\
 $(cxxcppflags) $(fcppflags) $(appcppflags)\

--- a/lib/mk/Make.rules.1d
+++ b/lib/mk/Make.rules.1d
@@ -24,6 +24,7 @@
 ### There are several user variables that control the behavior of the rules
 ###  defined here.  They are:
 ###    USE_64      if TRUE, use 64bit pointers on systems where 32bits is the default
+###    USE_ALIGNED_MEMORY if TRUE, allocate memory using posix_memalign
 ###    USE_COMPLEX if TRUE, enable the 'Complex' type
 ###                 (default is TRUE, disable only if compiler doesn't allow it)
 ###    USE_EB      if TRUE, build Chombo Embedded Boundary code

--- a/lib/mk/Make.rules.2d
+++ b/lib/mk/Make.rules.2d
@@ -24,6 +24,7 @@
 ### There are several user variables that control the behavior of the rules
 ###  defined here.  They are:
 ###    USE_64      if TRUE, use 64bit pointers on systems where 32bits is the default
+###    USE_ALIGNED_MEMORY if TRUE, allocate memory using posix_memalign
 ###    USE_COMPLEX if TRUE, enable the 'Complex' type
 ###                 (default is TRUE, disable only if compiler doesn't allow it)
 ###    USE_EB      if TRUE, build Chombo Embedded Boundary code

--- a/lib/mk/Make.rules.3d
+++ b/lib/mk/Make.rules.3d
@@ -24,6 +24,7 @@
 ### There are several user variables that control the behavior of the rules
 ###  defined here.  They are:
 ###    USE_64      if TRUE, use 64bit pointers on systems where 32bits is the default
+###    USE_ALIGNED_MEMORY if TRUE, allocate memory using posix_memalign
 ###    USE_COMPLEX if TRUE, enable the 'Complex' type
 ###                 (default is TRUE, disable only if compiler doesn't allow it)
 ###    USE_EB      if TRUE, build Chombo Embedded Boundary code

--- a/lib/mk/Make.rules.4d
+++ b/lib/mk/Make.rules.4d
@@ -24,6 +24,7 @@
 ### There are several user variables that control the behavior of the rules
 ###  defined here.  They are:
 ###    USE_64      if TRUE, use 64bit pointers on systems where 32bits is the default
+###    USE_ALIGNED_MEMORY if TRUE, allocate memory using posix_memalign
 ###    USE_COMPLEX if TRUE, enable the 'Complex' type
 ###                 (default is TRUE, disable only if compiler doesn't allow it)
 ###    USE_EB      if TRUE, build Chombo Embedded Boundary code

--- a/lib/mk/Make.rules.5d
+++ b/lib/mk/Make.rules.5d
@@ -24,6 +24,7 @@
 ### There are several user variables that control the behavior of the rules
 ###  defined here.  They are:
 ###    USE_64      if TRUE, use 64bit pointers on systems where 32bits is the default
+###    USE_ALIGNED_MEMORY if TRUE, allocate memory using posix_memalign
 ###    USE_COMPLEX if TRUE, enable the 'Complex' type
 ###                 (default is TRUE, disable only if compiler doesn't allow it)
 ###    USE_EB      if TRUE, build Chombo Embedded Boundary code

--- a/lib/mk/Make.rules.6d
+++ b/lib/mk/Make.rules.6d
@@ -24,6 +24,7 @@
 ### There are several user variables that control the behavior of the rules
 ###  defined here.  They are:
 ###    USE_64      if TRUE, use 64bit pointers on systems where 32bits is the default
+###    USE_ALIGNED_MEMORY if TRUE, allocate memory using posix_memalign
 ###    USE_COMPLEX if TRUE, enable the 'Complex' type
 ###                 (default is TRUE, disable only if compiler doesn't allow it)
 ###    USE_EB      if TRUE, build Chombo Embedded Boundary code


### PR DESCRIPTION
This will make Chombo use `malloc` if `USE_ALIGNED_MEMORY==FALSE` and `posix_memalign` if 
`USE_ALIGNED_MEMORY==TRUE`. The default is `FALSE` as `malloc` has been found to significantly reduce memory usage on some systems compared to allocating memory aligned with huge page boundaries (i.e. 2MB). If using aligned memory, one can also specify the alignment by defining the `CH_MEMORY_ALIGNMENT` macro appropriately (the default is `2*1024*1024` as before).