### PR TITLE
Add support for AArch64

### DIFF
--- a/lib/mk/compiler/Make.defs.GNU
+++ b/lib/mk/compiler/Make.defs.GNU
@@ -129,7 +129,7 @@ endif
 ifeq ($(USE_64),TRUE)
    # works on an AMD64 machine that defaults to 32bit
    # may also work on a Power{PC,4,5} but I'm not positive
-  deffcomflags += -m64
+#  deffcomflags += -m64
 endif
 
 ifeq ($(OPENMPCC),TRUE)

--- a/lib/src/BaseTools/ClockTicks.H
+++ b/lib/src/BaseTools/ClockTicks.H
@@ -59,10 +59,14 @@ inline unsigned long long int ch_ticks()
 }
 #define CH_TICKS
 #else
-// if we fall all the way through to here, we don't really do anything,
-// but we still need the NamespaceHeader to balance
-// the namespacefooter. (DFM 4/28/09)
+#include <time.h>
 #include "BaseNamespaceHeader.H"
+inline unsigned long long int ch_ticks()
+{
+  timespec temp;
+  clock_gettime(CLOCK_MONOTONIC, &temp);
+  return temp.tv_sec * 1000000000l + temp.tv_nsec;
+}
 #endif
 
 #include "BaseNamespaceFooter.H"

--- a/lib/src/BaseTools/ClockTicks.H
+++ b/lib/src/BaseTools/ClockTicks.H
@@ -58,6 +58,17 @@ inline unsigned long long int ch_ticks()
   return tbr;
 }
 #define CH_TICKS
+
+#elif defined(__aarch64__)
+#include "BaseNamespaceHeader.H"
+inline unsigned long long int ch_ticks()
+{
+  unsigned long long int virtual_timer_count;
+  asm volatile("mrs %0, cntvct_el0" : "=r"(virtual_timer_count));
+  return virtual_timer_count;
+}
+#define CH_TICKS
+
 #else
 #include <time.h>
 #include "BaseNamespaceHeader.H"
@@ -67,6 +78,8 @@ inline unsigned long long int ch_ticks()
   clock_gettime(CLOCK_MONOTONIC, &temp);
   return temp.tv_sec * 1000000000l + temp.tv_nsec;
 }
+
+#define CH_TICKS
 #endif
 
 #include "BaseNamespaceFooter.H"


### PR DESCRIPTION
This should allow building Chombo on Arm AArch64 computers (e.g. Apple Silicon Macs).